### PR TITLE
assert

### DIFF
--- a/pyiron_vasp/structure.py
+++ b/pyiron_vasp/structure.py
@@ -195,7 +195,8 @@ def atoms_from_string(string, read_velocities=False, species_list=None):
         else:
             atoms_dict["positions"] *= (-atoms_dict["scaling_factor"]) ** (1. / 3.)
 
-    assert (len(atoms_dict["positions"]) == n_atoms)
+    if not (len(atoms_dict["positions"]) == n_atoms):
+        raise AssertionError()
     velocities = list()
     if read_velocities:
         velocity_index = position_index + n_atoms + 1
@@ -204,7 +205,8 @@ def atoms_from_string(string, read_velocities=False, species_list=None):
             for j in range(3):
                 vec.append(float(string[i].split()[j]))
             velocities.append(vec)
-        assert (len(velocities) == n_atoms)
+        if not (len(velocities) == n_atoms):
+            raise AssertionError()
         atoms = _dict_to_atoms(atoms_dict, species_list=species_list)
         if atoms_dict["selective_dynamics"]:
             selective_dynamics = np.array(selective_dynamics)
@@ -255,7 +257,8 @@ def _dict_to_atoms(atoms_dict, species_list=None, read_from_first_line=False):
             symbol += atoms_dict["species_dict"][sp_key]["species"]
             symbol += str(atoms_dict["species_dict"][sp_key]["count"])
         elif read_from_first_line:
-            assert (len(atoms_dict["first_line"].split()) == len(atoms_dict["species_dict"].keys()))
+            if not (len(atoms_dict["first_line"].split()) == len(atoms_dict["species_dict"].keys())):
+                raise AssertionError()
             el_list = np.array(atoms_dict["first_line"].split()[i])
             el_list = np.tile(el_list, atoms_dict["species_dict"][sp_key]["count"])
             symbol += atoms_dict["first_line"].split()[i]

--- a/pyiron_vasp/vasp.py
+++ b/pyiron_vasp/vasp.py
@@ -344,9 +344,9 @@ class Vasp(GenericDFTJob):
                 if "vasprun.xml" in files:
                     vp_new.from_file(filename=posixpath.join(directory, "vasprun.xml"))
                     self.structure = vp_new.get_initial_structure()
-            except: # except AssertionError: 
-                 pass
-                 # raise AssertionError("OUTCAR/vasprun.xml should be present in order to import from directory")
+            except: # except AssertionError:
+                pass
+                # raise AssertionError("OUTCAR/vasprun.xml should be present in order to import from directory")
             if "INCAR" in files:
                 try:
                     self.input.incar.read_input(posixpath.join(directory, "INCAR"), ignore_trigger="!")

--- a/pyiron_vasp/vasp.py
+++ b/pyiron_vasp/vasp.py
@@ -344,8 +344,8 @@ class Vasp(GenericDFTJob):
                 if "vasprun.xml" in files:
                     vp_new.from_file(filename=posixpath.join(directory, "vasprun.xml"))
                     self.structure = vp_new.get_initial_structure()
-                except: 
-                    pass
+            except: 
+                pass
             if "INCAR" in files:
                 try:
                     self.input.incar.read_input(posixpath.join(directory, "INCAR"), ignore_trigger="!")

--- a/pyiron_vasp/vasp.py
+++ b/pyiron_vasp/vasp.py
@@ -339,7 +339,7 @@ class Vasp(GenericDFTJob):
                 files = os.listdir(directory)
             try:
                 if not ("OUTCAR" in files or "vasprun.xml" in files):
-                    pass
+                    raise IOError("This file isn't present")
                     # raise AssertionError("OUTCAR/vasprun.xml should be present in order to import from directory")
                 if "vasprun.xml" in files:
                     vp_new.from_file(filename=posixpath.join(directory, "vasprun.xml"))

--- a/pyiron_vasp/vasp.py
+++ b/pyiron_vasp/vasp.py
@@ -338,13 +338,12 @@ class Vasp(GenericDFTJob):
                                             universal_newlines=True)
                 files = os.listdir(directory)
             try:
-                assert ("OUTCAR" in files or "vasprun.xml" in files)
+                if not ("OUTCAR" in files or "vasprun.xml" in files):
+                    pass
+                    # raise AssertionError("OUTCAR/vasprun.xml should be present in order to import from directory")
                 if "vasprun.xml" in files:
                     vp_new.from_file(filename=posixpath.join(directory, "vasprun.xml"))
                     self.structure = vp_new.get_initial_structure()
-            except: # except AssertionError:
-                pass
-                # raise AssertionError("OUTCAR/vasprun.xml should be present in order to import from directory")
             if "INCAR" in files:
                 try:
                     self.input.incar.read_input(posixpath.join(directory, "INCAR"), ignore_trigger="!")
@@ -657,7 +656,8 @@ class Vasp(GenericDFTJob):
         if not symmetry_reduction:
             self.input.incar["ISYM"] = -1
         scheme_list = ["MP", "GP", "Line", "Manual"]
-        assert (scheme in scheme_list)
+        if not (scheme in scheme_list):
+            raise AssertionError()
         if scheme == "MP":
             if mesh is None:
                 if kmesh_density is not None:
@@ -674,7 +674,8 @@ class Vasp(GenericDFTJob):
                 raise ValueError("For the manual mode, the kpoints list should be specified")
             else:
                 if weights is not None:
-                    assert (len(manual_kpoints) == len(weights))
+                    if not (len(manual_kpoints) == len(weights)):
+                        raise AssertionError()
                 self.input.kpoints.set_value(line=1, val=str(len(manual_kpoints)))
                 if reciprocal:
                     self.input.kpoints.set_value(line=2, val="Reciprocal")
@@ -705,7 +706,8 @@ class Vasp(GenericDFTJob):
         if read_charge_density:
             self.input.incar["ICHARG"] = 11
         if structure is None:
-            assert (self._output_parser.structure is not None)
+            if not (self._output_parser.structure is not None):
+                raise AssertionError()
             structure = self._output_parser.structure
         from pyiron_dft.bandstructure import Bandstructure
         bs_obj = Bandstructure(structure)
@@ -725,7 +727,8 @@ class Vasp(GenericDFTJob):
         Returns:
             pyiron_atomistics.structure.atoms.Atoms: The required structure
         """
-        assert (self.structure is not None)
+        if not (self.structure is not None):
+            raise AssertionError()
         snapshot = self.structure.copy()
         snapshot.cell = self.get("output/generic/cells")[iteration_step]
         snapshot.positions = self.get("output/generic/positions")[iteration_step]
@@ -773,7 +776,8 @@ class Vasp(GenericDFTJob):
         .. _Neugebauer & Scheffler: https://doi.org/10.1103/PhysRevB.46.16067
 
         """
-        assert (direction in range(3))
+        if not (direction in range(3)):
+            raise AssertionError()
         self.input.incar["ISYM"] = 0
         self.input.incar["LORBIT"] = 11
         self.input.incar["IDIPOL"] = direction + 1
@@ -986,8 +990,10 @@ class Vasp(GenericDFTJob):
         Returns:
 
         """
-        assert isinstance(direction, bool)
-        assert isinstance(norm, bool)
+        if not isinstance(direction, bool):
+            raise AssertionError()
+        if not isinstance(norm, bool):
+            raise AssertionError()
         if direction and norm:
             self.input.incar['I_CONSTRAINED_M'] = 2
         elif direction:
@@ -1187,7 +1193,8 @@ class Output:
             self.structure.cell = log_dict["cells"][-1]
 
         else:
-            assert ("OUTCAR" in files_present)
+            if not ("OUTCAR" in files_present):
+                raise AssertionError()
             log_dict = self.outcar.parse_dict.copy()
             log_dict["energy_tot"] = log_dict["energies"].copy()
             if len(log_dict["magnetization"]) > 0:
@@ -1573,7 +1580,8 @@ class Potcar(GenericParameters):
             else:
                 el_path = self._find_potential_file(path=vasp_potentials.find_default(el)['Filename'].values[0][0])
 
-            assert (os.path.isfile(el_path))
+            if not (os.path.isfile(el_path)):
+                raise AssertionError()
             pot_name = "pot_" + str(i)
 
             if pot_name in self._dataset["Parameter"]:

--- a/pyiron_vasp/vasp.py
+++ b/pyiron_vasp/vasp.py
@@ -344,8 +344,9 @@ class Vasp(GenericDFTJob):
                 if "vasprun.xml" in files:
                     vp_new.from_file(filename=posixpath.join(directory, "vasprun.xml"))
                     self.structure = vp_new.get_initial_structure()
-            except: 
-                pass
+            except: # except AssertionError: 
+                 pass
+                 # raise AssertionError("OUTCAR/vasprun.xml should be present in order to import from directory")
             if "INCAR" in files:
                 try:
                     self.input.incar.read_input(posixpath.join(directory, "INCAR"), ignore_trigger="!")

--- a/pyiron_vasp/vasp.py
+++ b/pyiron_vasp/vasp.py
@@ -344,6 +344,8 @@ class Vasp(GenericDFTJob):
                 if "vasprun.xml" in files:
                     vp_new.from_file(filename=posixpath.join(directory, "vasprun.xml"))
                     self.structure = vp_new.get_initial_structure()
+                except: 
+                    pass
             if "INCAR" in files:
                 try:
                     self.input.incar.read_input(posixpath.join(directory, "INCAR"), ignore_trigger="!")

--- a/pyiron_vasp/vasprun.py
+++ b/pyiron_vasp/vasprun.py
@@ -48,7 +48,8 @@ class Vasprun(object):
         Args:
             filename (str): Path to the vasprun file
         """
-        assert(os.path.isfile(filename))
+        if not (os.path.isfile(filename)):
+            raise AssertionError()
         try:
             self.root = ETree.parse(filename).getroot()
         except ETree.ParseError:
@@ -121,7 +122,8 @@ class Vasprun(object):
             node (lxml.etree.Element instance): The node to parse
             d (dict): The dictionary to which data is to be parsed
         """
-        assert(node.tag == "kpoints")
+        if not (node.tag == "kpoints"):
+            raise AssertionError()
         for leaf in node:
             if leaf.tag == "generation":
                 d[leaf.tag] = dict()
@@ -155,7 +157,8 @@ class Vasprun(object):
             node (lxml.etree.Element instance): The node to parse
             d (dict): The dictionary to which data is to be parsed
         """
-        assert (node.tag == "atominfo")
+        if not (node.tag == "atominfo"):
+            raise AssertionError()
         species_dict = OrderedDict()
         for leaf in node:
             if leaf.tag == "atoms":
@@ -203,7 +206,8 @@ class Vasprun(object):
             node (lxml.etree.Element instance): The node to parse
             d (dict): The dictionary to which data is to be parsed
         """
-        assert(node.tag == "dos")
+        if not (node.tag == "dos"):
+            raise AssertionError()
         for item in node:
             if item.tag == "i":
                 self.parse_item_to_dict(item, d)
@@ -216,7 +220,8 @@ class Vasprun(object):
             node (lxml.etree.Element instance): The node to parse
             d (dict): The dictionary to which data is to be parsed
         """
-        assert(node.tag == "total")
+        if not (node.tag == "total"):
+            raise AssertionError()
         for item in node:
             if item.tag == "array":
                 for ii in item:
@@ -248,7 +253,8 @@ class Vasprun(object):
             node (lxml.etree.Element instance): The node to parse
             d (dict): The dictionary to which data is to be parsed
         """
-        assert (node.tag == "partial")
+        if not (node.tag == "partial"):
+            raise AssertionError()
         orbital_dict = dict()
         orbital_index = 0
         for item in node:
@@ -286,7 +292,8 @@ class Vasprun(object):
             node (lxml.etree.Element instance): The node to parse
             d (dict): The dictionary to which data is to be parsed
         """
-        assert(node.tag == "projected")
+        if not (node.tag == "projected"):
+            raise AssertionError()
         orbital_dict = dict()
         orbital_index = 0
         for item in node:
@@ -322,7 +329,8 @@ class Vasprun(object):
             d (dict): Dictionary to containing parsed data
         """
         d = dict()
-        assert(node.tag == "scstep")
+        if not (node.tag == "scstep"):
+            raise AssertionError()
         for item in node:
             if item.tag == "energy":
                 for i in item:
@@ -411,7 +419,8 @@ class Vasprun(object):
             node (lxml.etree.Element instance): The node to parse
             d (dict): The dictionary to which data is to be parsed
         """
-        assert(node.tag == "eigenvalues")
+        if not (node.tag == "eigenvalues"):
+            raise AssertionError()
         grand_eigenvalue_matrix = list()
         grand_occupancy_matrix = list()
         for item in node:
@@ -445,7 +454,8 @@ class Vasprun(object):
             node (lxml.etree.Element instance): The node to parse
             d (dict): The dictionary to which data is to be parsed
         """
-        assert(node.tag == "structure")
+        if not (node.tag == "structure"):
+            raise AssertionError()
         for leaf in node:
             if leaf.tag == "crystal":
                 for item in leaf:
@@ -487,7 +497,8 @@ class Vasprun(object):
             node (lxml.etree.Element instance): The node to parse
             d (dict): The dictionary to which data is to be parsed
         """
-        assert (node.tag == "parameters")
+        if not (node.tag == "parameters"):
+            raise AssertionError()
         self.parse_recursively(node, d, key_name="parameters")
 
     def parse_recursively(self, node, d, key_name=None):


### PR DESCRIPTION
It was discovered that some projects used assert to enforce interface constraints. However, assert is removed with compiling to optimised byte code (python -o producing *.pyo files). This caused various protections to be removed. The use of assert is also considered as general bad practice in OpenStack codebases.